### PR TITLE
New 4 words register datatypes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,12 +355,25 @@ doubleValue: Value to be converted
 register_order: Desired Word Order (Low Register first or High Register first - Default: RegisterOrder.lowHigh  
 return: 16 Bit Register values int[]  
 
+**def convert_quad_to_four_registers(quadValue, register_order=RegisterOrder.lowHigh):
+
+Convert 64 Bit Value to four 16 Bit Value to send as Modbus Registers
+quadValue: Value to be converted
+register_order: Desired Word Order (Low Register first or High Register first - Default: RegisterOrder.lowHigh
+return: 16 Bit Register values int[]
+
 **def convert_float_to_two_registers(floatValue, register_order=RegisterOrder.lowHigh)**
 
 Convert 32 Bit real Value to two 16 Bit Value to send as Modbus Registers  
 floatValue: Value to be converted  
 register_order: Desired Word Order (Low Register first or High Register first - Default: RegisterOrder.lowHigh  
 return: 16 Bit Register values int[]  
+
+**def convert_float64_to_four_registers(float64Value, register_order=RegisterOrder.lowHigh):
+
+Convert 64 Bit real Value to two 16 Bit Value to send as Modbus Registers
+floatValue: Value to be converted
+return: 16 Bit Register values int[]
 
 **def convert_registers_to_double(registers, register_order=RegisterOrder.lowHigh)**
 
@@ -369,9 +382,21 @@ registers: 16 Bit Registers
 register_order: Desired Word Order (Low Register first or High Register first - Default: RegisterOrder.lowHigh  
 return: 32 bit value  
 
+def convert_registers_to_quad(registers, register_order=RegisterOrder.lowHigh):
+
+Convert four 16 Bit Registers to 64 Bit long value - Used to receive 64Bit values from Modbus (Modbus Registers are 16 Bit long)
+registers: 16 Bit Registers
+return: 64 bit value
+
 **def convert_registers_to_float(registers, register_order=RegisterOrder.lowHigh)**
 
 Convert two 16 Bit Registers to 32 Bit real value - Used to receive float values from Modbus (Modbus Registers are 16 Bit long)  
 registers: 16 Bit Registers  
 register_order: Desired Word Order (Low Register first or High Register first - Default: RegisterOrder.lowHigh  
 return: 32 bit value real 
+
+**def convert_registers_to_float64(registers, register_order=RegisterOrder.lowHigh):
+
+Convert two 16 Bit Registers to 64 Bit real value - Used to receive float values from Modbus (Modbus Registers are 16 Bit long)
+registers: 16 Bit Registers
+return: 64 bit value real

--- a/easymodbus/modbusClient.py
+++ b/easymodbus/modbusClient.py
@@ -191,7 +191,7 @@ class ModbusClient(object):
         """
         logging.info("Request to read Input Registers (FC04), starting address: {0}, quantity: {1}"
                      .format(str(starting_address), str(quantity)))
-        return_value = self.read_execute_read_order(starting_address, quantity, FunctionCode.READ_INPUT_REGISTERS)
+        return_value = self.execute_read_order(starting_address, quantity, FunctionCode.READ_INPUT_REGISTERS)
         logging.info("Response to Input Registers (FC04), values: {0}"
                      .format(str(return_value)))
         return return_value

--- a/easymodbus/modbusClient.py
+++ b/easymodbus/modbusClient.py
@@ -591,7 +591,7 @@ def convert_quad_to_four_registers(quadValue, register_order=RegisterOrder.lowHi
     return myList
 
 
-def convert_float32_to_two_registers(floatValue, register_order=RegisterOrder.lowHigh):
+def convert_float_to_two_registers(floatValue, register_order=RegisterOrder.lowHigh):
     """
     Convert 32 Bit real Value to two 16 Bit Value to send as Modbus Registers
     floatValue: Value to be converted
@@ -654,7 +654,7 @@ def convert_registers_to_quad(registers, register_order=RegisterOrder.lowHigh):
     return returnValue
 
 
-def convert_registers_to_float32(registers, register_order=RegisterOrder.lowHigh):
+def convert_registers_to_float(registers, register_order=RegisterOrder.lowHigh):
     """
     Convert two 16 Bit Registers to 32 Bit real value - 
     Used to receive float values from Modbus (Modbus Registers are 16 Bit long)

--- a/easymodbus/modbusClient.py
+++ b/easymodbus/modbusClient.py
@@ -444,14 +444,14 @@ class ModbusClient(object):
     @property
     def parity(self):
         """
-        Gets the of Parity in case of serial connection
+        Gets the value of Parity in case of serial connection
         """
         return self.__parity
 
     @parity.setter
     def parity(self, parity):
         """
-        Sets the of Parity in case of serial connection
+        Sets the value of Parity in case of serial connection
         Example modbusClient.Parity = Parity.even
         """
         self.__parity = parity

--- a/easymodbus/modbus_protocol.py
+++ b/easymodbus/modbus_protocol.py
@@ -96,7 +96,7 @@ class PDU:
             if exception_code == 1:
                 raise Exceptions.function_codeNotSupportedException("Function code not supported by master")
             elif exception_code == 2:
-                raise Exceptions.starting_AddressInvalidException(
+                raise Exceptions.StartingAddressInvalidException(
                     "Starting address invalid or starting address + quantity invalid")
             elif exception_code == 3:
                 raise Exceptions.QuantityInvalidException("quantity invalid")

--- a/easymodbus/modbus_protocol.py
+++ b/easymodbus/modbus_protocol.py
@@ -78,7 +78,8 @@ class MBAPHeader:
 @dataclass
 class PDU:
     """
-    Dataclass which represents the PDU (Protocol Data Unit) - Both for Modbus RTU and Modbus TCP
+    Dataclass which represents the PDU (Protocol Data Unit) 
+    - Both for Modbus RTU and Modbus TCP
     function_code(1 Byte): Service specified by the Function code
     """
     function_code: FunctionCode = FunctionCode.READ_COILS
@@ -108,7 +109,8 @@ class PDU:
 @dataclass
 class ADU:
     """
-    Dataclass which represents the ADU (Application Data Unit) - Both for Modbus RTU and Modbus TCP
+    Dataclass which represents the ADU (Application Data Unit) 
+    - Both for Modbus RTU and Modbus TCP
     mbap_header: only relevant for Modbus TCP
     pdu: both for Modbus TCP and RTU
     crc: Error check only relevant for Modbus RTU

--- a/easymodbus/modbus_protocol.py
+++ b/easymodbus/modbus_protocol.py
@@ -96,7 +96,7 @@ class PDU:
             if exception_code == 1:
                 raise Exceptions.function_codeNotSupportedException("Function code not supported by master")
             elif exception_code == 2:
-                raise Exceptions.starting_addressInvalidException(
+                raise Exceptions.starting_AddressInvalidException(
                     "Starting address invalid or starting address + quantity invalid")
             elif exception_code == 3:
                 raise Exceptions.QuantityInvalidException("quantity invalid")

--- a/easymodbus/run.py
+++ b/easymodbus/run.py
@@ -6,7 +6,7 @@ Created on 12.09.2016
 '''
 
 # @UnresolvedImport
-from modbusClient import *
+from easymodbus.modbusClient import *
 # @UnresolvedImport
     
 modbusClient = ModbusClient('127.0.0.1', 502)


### PR DESCRIPTION
I found your EasyModbus written in python and I think is a very good work!
In my case I need some more datatypes because in energy measures we have registers as 4 words.
Furthermore when I tried to read Input registers it gave me an error because it calls a unexistent function "read_analog"; I modified it with "execute_read_order" and now it works.
Thank you very much for your nice work.